### PR TITLE
Adds a comment to the review status line

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,4 +11,4 @@ triggers:
       - "features/*"
 
 reviews:
-  review_status: true   
+  review_status: true   # Auto review pr on developp


### PR DESCRIPTION
Adds a comment to the review status line in the configuration file.

This clarifies the purpose of enabling the review status feature, indicating that it's for auto-review on development branches.